### PR TITLE
Added ability to define custom malware hashes

### DIFF
--- a/app/server/game_functions.py
+++ b/app/server/game_functions.py
@@ -454,22 +454,5 @@ def create_malware() -> "list[Malware]":
     for path in malware_configs:
         malware_objects.append(load_malware_obj_from_yaml_by_file(path))
     
-    malware_objects = assign_hash_to_malware(malware_objects)
-    return malware_objects
-
-def assign_hash_to_malware(malware_objects: "list[Malware]") -> "list[Malware]":
-    """
-    Take all available VT hashes and assign them to malware families 
-    there should be a 1-1 mapping of hash to malware family
-    """
-    # Look through available hashes and assign them to malware families via a round robin
-    while FILES_MALICIOUS_VT_SEED_HASHES:
-        for malware_object in malware_objects:
-            if not FILES_MALICIOUS_VT_SEED_HASHES:
-                break
-            # take a hash and remove it from our list of hashes
-            hash = FILES_MALICIOUS_VT_SEED_HASHES.pop()
-            malware_object.hashes.append(hash) # TODO: This might not work!!
-   
     return malware_objects
 

--- a/app/server/modules/file/malware.py
+++ b/app/server/modules/file/malware.py
@@ -7,20 +7,37 @@ class Malware:
     """
     A class to model malware
     """
-    def __init__(self, name:str, filenames:list, paths:list, recon_processes:"list[dict]", 
+    def __init__(self, name:str, files:dict, paths:list, recon_processes:"list[dict]", 
                    c2_processes:"list[dict]", obfuscation_techniques:list=None) -> None:
         self.name = name
-        self.filenames = filenames
+        self.files = []
         self.paths = paths
         self.recon_processes = []
         self.c2_processes = []
         self.obfuscation_techniques = obfuscation_techniques
 
+        self.set_files(files)
         self.set_recon_processes(recon_processes)
         self.set_c2_processes(c2_processes)
 
-        self.hashes = []
-        # self.c2_ips = c2_ips
+    def set_files(self, files_dict):
+        from app.server.game_functions import FILES_MALICIOUS_VT_SEED_HASHES
+
+        for file in files_dict:
+            filename = file['filename']
+            hashes = file.get('hashes', [])
+            if not hashes:
+                # no hashes were provided, get some from the defaults
+                for i in range(3):
+                    hash_to_add = FILES_MALICIOUS_VT_SEED_HASHES.pop()
+                    hashes.append(hash_to_add)
+            self.files.append({'filename': filename, 'hashes': hashes})
+
+    def get_file_hashes(self, filename):
+        for file in self.files:
+            if file['filename'] == filename:
+                return file['hashes']
+        return []
 
 
     def set_recon_processes(self, processes:"list[dict]") -> None:
@@ -47,11 +64,11 @@ class Malware:
         """
         Returns a file from the malware family
         """
-        filename = random.choice(self.filenames)
+        file = random.choice(self.files)
         return File(
-            filename=filename,
-            path=random.choice(self.paths)+filename,
-            sha256=random.choice(self.hashes)
+            filename=file["filename"],
+            path=random.choice(self.paths)+ file["filename"],
+            sha256=random.choice(file["hashes"])
         )
 
     def get_recon_process(self) -> Process:


### PR DESCRIPTION
changed the way malware configs are defines to allow for custom hashes to be injected

Went from 

```yaml
name: goldenrabbit
filenames:
  - a.exe
  - svchost.exe
  - msdtc.exe
paths:
  - C:\ProgramData\PST\
  - C:\
recon_processes:
```

To:

```yaml
name: goldenrabbit
files:
  - filename: a.exe
    hashes:
      - 42530f9f92f2440d66b96e610d07b5256566fe47af2fd6e01cd9e1cd9b85c01e
  - filename: svchost.exe
    hashes:
      - 9bd6a46182f145240e766380d2df56f299ef36dc05ed1f4637b75514c4fd051e
      - 0c3eff5d888cfd0c4c7f1cbc43fad5ca529e70c1a7edc6fcafadca9ebf1e3f88
      - b54a65ca16116b92c6fe5eb6c046b5e7e91aab377703ad51c7def93f725a8c42
  - filename: msdtc.exe
paths:
  - C:\ProgramData\PST\
  - C:\
  ```