### PR TITLE
Abstracting config validator to yaml files

### DIFF
--- a/app/static_configs/actor_validator.yaml
+++ b/app/static_configs/actor_validator.yaml
@@ -1,0 +1,42 @@
+mandatory:
+  - name
+  - effectiveness
+  - count_init_passive_dns
+  - activity_start_date
+  - activity_end_date
+  - activity_start_hour
+  - workday_length_hours
+  - working_days
+  - attacks
+optional:
+  malware: post_exploit_commands
+conditional:
+  attack:
+    "recon:browsing":
+      - recon_search_terms
+    "watering_hole:malware_delivery":
+      - watering_hole_target_roles
+      - watering_hole_domains
+      - domain_themes
+      - file_names
+      - malware
+    "watering_hole:phishing":
+      - watering_hole_target_roles
+      - watering_hole_domains
+      - domain_themes
+      - subjects
+    "email:malware_delivery":
+      - domain_themes
+      - sender_themes
+      - file_names
+      - subjects
+      - malware
+    "email:phishing":
+      - domain_themes
+      - sender_themes
+      - subjects
+  
+# format:
+#   age: "{:d}"
+#   email: "[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}"
+#   phone: "\d{3}-\d{3}-\d{4}"

--- a/app/static_configs/company_validator.yaml
+++ b/app/static_configs/company_validator.yaml
@@ -1,0 +1,11 @@
+mandatory:
+  - partners
+  - activity_start_date
+  - activity_end_date
+  - activity_start_hour
+  - workday_length_hours
+  - working_days
+optional:
+  roles: title
+  roles: limit
+  roles: somethingelse

--- a/app/static_configs/malware_validator.yaml
+++ b/app/static_configs/malware_validator.yaml
@@ -1,0 +1,12 @@
+mandatory:
+  - name
+  - files
+  - paths
+  - recon_processes
+  - c2_processes
+optional:
+  recon_processes: name
+  recon_processes: process
+  c2_processes: name
+  c2_processes: process
+  files: filename


### PR DESCRIPTION
I'm abstracting the config validator to a set of yaml configs.
We can define the validator for each config type in the static_configs folder.

```yaml
mandatory:
  - name
  - effectiveness
  - count_init_passive_dns
  - activity_start_date
  - activity_end_date
  - activity_start_hour
  - workday_length_hours
  - working_days
  - attacks
optional:
  malware: post_exploit_commands
conditional:
  attack:
    "recon:browsing":
      - recon_search_terms
    "watering_hole:malware_delivery":
      - watering_hole_target_roles
      - watering_hole_domains
      - domain_themes
      - file_names
      - malware
    "watering_hole:phishing":
      - watering_hole_target_roles
      - watering_hole_domains
      - domain_themes
      - subjects
    "email:malware_delivery":
      - domain_themes
      - sender_themes
      - file_names
      - subjects
      - malware
    "email:phishing":
      - domain_themes
      - sender_themes
      - subjects
   ```

Then we can call the validator by supplying a config type

```python
read_config_from_yaml(yaml_file, config_type="Actor")
```