### PR TITLE
Make all the error print at once, so user can debug in once fell swoop

### DIFF
--- a/app/server/modules/helpers/config_helper.py
+++ b/app/server/modules/helpers/config_helper.py
@@ -28,16 +28,18 @@ def read_config_from_yaml(path, config_type=None) -> dict:
         # Load the requirements file
         with open(requirements_file_path, 'r') as f:
             requirements = yaml.safe_load(f)
+
+        errors = []
         
         # Check for mandatory keys
         for key in requirements['mandatory']:
             if key not in config:
-                raise ValueError(f"Missing mandatory key: {key}")
+                errors.append(f"Missing mandatory key: {key}")
         
         # Check for optional keys
         for key, required_key in requirements['optional'].items():
             if required_key in config and key not in config:
-                raise ValueError(f"You must provide the key \"{key}\" if you are using the key \"{required_key}\"")
+                errors.append(f"You must provide the key \"{key}\" if you are using the key \"{required_key}\"")
         
         # Check for keys required based on the value of other keys
         for key, required_keys in requirements.get('conditional', {}).items():
@@ -48,7 +50,11 @@ def read_config_from_yaml(path, config_type=None) -> dict:
             if value in required_keys:
                 for required_key in required_keys[value]:
                     if required_key not in config:
-                        raise ValueError(f"Missing key '{required_key}' required by '{key}'='{value}'")
+                        errors.append(f"Missing key '{required_key}' required by '{key}'='{value}'")
+
+        if errors:
+            error_message= "Found the following config errors: \n" + "\n\t-> " + "\n\t-> ".join(errors)
+            raise ValueError(error_message)
 
 
         # # Check for keys with defined formats


### PR DESCRIPTION
Users shouldn't have to run the engine multiple times in order to find all the config errors
Print all the errors at once for each config file.

Hopefully we can bring this into the view at some point

```
ValueError: Found the following config errors: 

	-> Missing mandatory key: activity_end_date
	-> You must provide the key "malware" if you are using the key "post_exploit_commands"
```