### PR TITLE
Abstract hostname to host class

### DIFF
--- a/app/server/modules/endpoints/endpoint_controller.py
+++ b/app/server/modules/endpoints/endpoint_controller.py
@@ -52,7 +52,7 @@ def gen_system_files_on_host(start_date: date, start_hour: int, workday_length_h
             time = Clock.generate_bimodal_timestamp(start_date, start_hour, workday_length_hours).timestamp()
             
             file_creation_event = FileCreationEvent(
-                hostname=employee.hostname, #Pick a random employee to generate system files
+                hostname=employee.endpoint.name, #Pick a random employee to generate system files
                 username=employee.username, # Get this from the random employee
                 timestamp=time,
                 filename=filename, # Get the filename from the path 
@@ -64,7 +64,7 @@ def gen_system_files_on_host(start_date: date, start_hour: int, workday_length_h
             if random.random() < current_app.config['FP_RATE_HOST_ALERTS'] and ".exe" in filename: #FP: Use reports legit system file
                 generate_host_alert(
                     time=Clock.delay_time_by(time, factor="minutes"),
-                    hostname=employee.hostname,
+                    hostname=employee.endpoint.name,
                     filename=filename,
                     sha256=hash
                 )
@@ -97,7 +97,7 @@ def gen_system_processes_on_host(start_date: date, start_hour: int, workday_leng
                     parent_process_hash=parent_hash,
                     process_commandline=process.process_commandline,
                     process_name=process.process_name,
-                    hostname=employee.hostname,
+                    hostname=employee.endpoint.name,
                     username=employee.username,
                 )
                 upload_endpoint_event_to_azure(process_event, table_name="ProcessEvents")
@@ -117,7 +117,7 @@ def gen_system_processes_on_host(start_date: date, start_hour: int, workday_leng
                     parent_process_hash=parent_hash,
                     process_commandline=process.process_commandline,
                     process_name=process.process_name,
-                    hostname=employee.hostname,
+                    hostname=employee.endpoint.name,
                     username="System"
                 )
                 upload_endpoint_event_to_azure(process_event, table_name="ProcessEvents")
@@ -190,7 +190,7 @@ def gen_user_files_on_host(start_date: date, start_hour: int, workday_length_hou
                 category='office'
                 
             write_file_to_host(
-                hostname=employee.hostname,
+                hostname=employee.endpoint.name,
                 username=employee.username,
                 process_name=random.choice(FILE_CREATING_PROCESSES),
                 timestamp=Clock.generate_bimodal_timestamp(start_date, start_hour, workday_length_hours).timestamp(),
@@ -202,7 +202,7 @@ def gen_user_files_on_host(start_date: date, start_hour: int, workday_length_hou
     # This will create legit executables/applications
     for employee in random.choices(employees, k=10): #FIX THIS LATER
         write_file_to_host(
-            hostname=employee.hostname,
+            hostname=employee.endpoint.name,
             username=employee.username,
             process_name=random.choice(FILE_CREATING_PROCESSES),
             timestamp=Clock.generate_bimodal_timestamp(start_date, start_hour, workday_length_hours).timestamp(),

--- a/app/server/modules/host/host.py
+++ b/app/server/modules/host/host.py
@@ -1,0 +1,44 @@
+from app import db
+
+class Host(db.Model):
+    """
+    A class to model a host/machine
+    """
+
+    __tablename__ = 'hosts'
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(100))
+    host_type = db.Column(db.String(50))
+
+    def __init__(self, name: str, host_type: str) -> None:
+        self.name = name
+        self.host_type = host_type
+
+
+class Endpoint(Host):
+    """
+    A class to model a endpoint 
+    Endpoints are devices like laptops and desktop used by individual users
+    From simplification, we have a 1-1 relationship for User <-> Endpoint
+    """
+
+    employee_id = db.Column(db.Integer, db.ForeignKey('employee.id'))
+
+    def __init__(self, name: str) -> None:
+        super().__init__(name, host_type="endpoint")
+
+
+class Server(Host):
+    """
+    A class to model a server 
+    Servers are not directly associated with any one user
+    Servers can be of multiple types including
+    - Exchange, SSH, VPN, File, Web
+    """
+
+    def __init__(self, name: str, server_type: str) -> None:
+        super().__init__(name, host_type="server")
+
+        self.server_type = server_type
+
+

--- a/app/server/modules/host/host.py
+++ b/app/server/modules/host/host.py
@@ -1,4 +1,5 @@
 from app import db
+from app.server.modules.organization.Company import Company
 
 class Host(db.Model):
     """
@@ -13,6 +14,9 @@ class Host(db.Model):
     def __init__(self, name: str, host_type: str) -> None:
         self.name = name
         self.host_type = host_type
+
+    def __repr__(self) -> str:
+        return '<Host %r>' % self.name
 
 
 class Endpoint(Host):
@@ -35,6 +39,8 @@ class Server(Host):
     Servers can be of multiple types including
     - Exchange, SSH, VPN, File, Web
     """
+    company_id = db.Column(db.Integer, db.ForeignKey('company.id'))
+    # company = db.relationship('Company', backref=db.backref('servers', lazy='dynamic'))
 
     def __init__(self, name: str, server_type: str) -> None:
         super().__init__(name, host_type="server")

--- a/app/server/modules/organization/Company.py
+++ b/app/server/modules/organization/Company.py
@@ -13,7 +13,6 @@ from datetime import date, timedelta, datetime
 from app.server.models import Base
 from app.server.modules.clock.Clock import Clock
 from app.server.models import GameSession
-from app.server.modules.host.host import Endpoint
 
 from app import db
 
@@ -40,6 +39,8 @@ class Company(Base):
     workday_length_hours    = db.Column(db.Integer())
     count_employees         = db.Column(db.Integer())
     working_days            = db.Column(db.String(300))
+
+    servers                 = db.relationship('Server', backref='company')
 
     def __init__(self, name: str, domain: str, activity_start_date: str, activity_end_date: str, activity_start_hour: int, 
                  workday_length_hours: int, working_days: list=[], count_employees:int=100, roles:dict={}, partners:list=[]) -> None:
@@ -157,7 +158,7 @@ class Company(Base):
         Role Dict should look something like: 
           "roles": [
             {
-            "role": "Chief Executive Officer",
+            "role": "Chief Executive Officer",1
             "limit": 1
             },
             {
@@ -286,6 +287,8 @@ class Employee(Base):
 
         Example: X7O9-DESTOP
         """
+        from app.server.modules.host.host import Endpoint
+
         prefix = random.choices(string.ascii_letters + string.digits, k=4)
         prefix = str.upper("".join(prefix))
         postfix = random.choice(["DESKTOP", "LAPTOP", "MACHINE"])
@@ -303,6 +306,7 @@ class Employee(Base):
         A function to return the JSON representation of the employee object.
         Used for uploading data to ADX.
         """
+
         return {
             "timestamp": self.timestamp,
             "name": self.name,

--- a/app/server/modules/organization/company_controller.py
+++ b/app/server/modules/organization/company_controller.py
@@ -10,6 +10,7 @@ from app.server.models import db
 from app.server.modules.organization.Company import Company, Employee
 from app.server.modules.logging.uploadLogs import LogUploader
 from app.server.modules.clock.Clock import Clock
+from app.server.modules.host.host import Server
 from app.server.modules.helpers.config_helper import read_config_from_yaml
 
 # instantiate faker
@@ -47,14 +48,23 @@ def create_company():
     # loads json file as diction
     company_config = read_config_from_yaml('app/game_configs/company.yaml', config_type="Company")
     # instantiate a company object using config info
+
+    servers = company_config.pop("servers")
     # print(company_config)
     company = Company(
             **company_config
     )
-     # add the company to the database
-    
 
-    # Create 100 employees that work for the company
+    for server in servers:
+        new_server = Server(
+            name=server["name"], 
+            server_type=server["type"]
+        )
+        company.servers.append(new_server)
+        db.session.add(new_server)
+
+    print(company.servers)
+    # Create N employees that work for the company
     # Specify how long they have been working at the company
     employees = []
     for _ in range(company.count_employees):

--- a/app/server/modules/triggers/Trigger.py
+++ b/app/server/modules/triggers/Trigger.py
@@ -132,7 +132,7 @@ class Trigger:
         path = f"C:\\Users\\{recipient.username}\\Downloads\\{filename}"
         process = random.choice(['Edge.exe','chrome.exe','edge.exe','firefox.exe']) 
         file_creation_event = FileCreationEvent(
-            hostname=recipient.hostname,
+            hostname=recipient.endpoint.name,
             username=recipient.username,
             timestamp=time,
             filename=filename,
@@ -161,7 +161,7 @@ class Trigger:
                     Trigger.email_attachment_drops_payload(filename, recipient, payload_time, actor)
                 else:
                     # Qurantine the file and send an alert
-                    generate_host_quarantine_alert(time=payload_time, hostname=recipient.hostname, filename=filename, sha256="-")
+                    generate_host_quarantine_alert(time=payload_time, hostname=recipient.endpoint.name, filename=filename, sha256="-")
 
     @staticmethod
     def email_attachment_drops_payload(attachment_name:str, recipient: Employee, time: float, actor: Actor) -> None:
@@ -188,7 +188,7 @@ class Trigger:
         malware = get_malware_by_name(malware_family_to_drop)
         implant = malware.get_implant()
         write_file_to_host(
-            hostname=recipient.hostname,
+            hostname=recipient.endpoint.name,
             username=recipient.username,
             timestamp=time,
             file=implant,
@@ -198,7 +198,7 @@ class Trigger:
         if random.random() < current_app.config['TP_RATE_HOST_ALERTS']:
             generate_host_alert(
                 time=Clock.delay_time_by(start_time=time, factor="minutes"),
-                hostname=recipient.hostname,
+                hostname=recipient.endpoint.name,
                 filename=implant.filename,
                 sha256=implant.sha256
             )
@@ -233,7 +233,7 @@ class Trigger:
         for process in [recon_process, c2_process]:
             time = Clock.delay_time_by(start_time=time, factor="minutes")
             create_process_on_host(
-                hostname=recipient.hostname,
+                hostname=recipient.endpoint.name,
                 timestamp=time,
                 parent_process_name=payload.filename,
                 parent_process_hash=payload.sha256,
@@ -286,7 +286,7 @@ class Trigger:
 
             time = Clock.delay_time_by(start_time=time, factor="seconds")
             create_process_on_host(
-                hostname=recipient.hostname,
+                hostname=recipient.endpoint.name,
                 timestamp=time,
                 parent_process_name=process_obj.process_name,
                 parent_process_hash=process.get("hash", None) or "614ca7b627533e22aa3e5c3594605dc6fe6f000b0cc2b845ece47ca60673ec7f",


### PR DESCRIPTION

Host are now in their own class. 
There are two kinds: endpoints and servers 

```python
class Host(db.Model):
    """
    A class to model a host/machine
    """

    __tablename__ = 'hosts'
    id = db.Column(db.Integer, primary_key=True)
    name = db.Column(db.String(100))
    host_type = db.Column(db.String(50))
    ....

class Endpoint(Host):
    """
    A class to model a endpoint 
    Endpoints are devices like laptops and desktop used by individual users
    From simplification, we have a 1-1 relationship for User <-> Endpoint
    """
    employee_id = db.Column(db.Integer, db.ForeignKey('employee.id'))

    def __init__(self, name: str) -> None:
        super().__init__(name, host_type="endpoint")

class Server(Host):
    """
    A class to model a server 
    Servers are not directly associated with any one user
    Servers can be of multiple types including
    - Exchange, SSH, VPN, File, Web
    """
    company_id = db.Column(db.Integer, db.ForeignKey('company.id'))

    ...

```

There is a 1-1 relationship between users and endpoints
There is a 1-many relationship between the company and servers

Employee hostnames are now derives from endpoints names